### PR TITLE
Cursor snap to the nearest point relative to last mouse position

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ The plugin supports these options:
                 relativeX or x or x2 or x3 ..: number,
                 relativeY or y or y2 or y3 ..: number
             },
-            mousePosition: {
-                relativeX: number,
-                relativeY: number
-            },
             show: true or false,
             showLabel: true or false,
             snapToPlot: number,
@@ -127,7 +123,7 @@ The plugin adds some public methods to the plot:
 * plot.formatCursorPosition(plot, cursor)
 
     return the formatted text values of the position of cursor as an 
-	object { xTextValue, yTextValue }
+    object { xTextValue, yTextValue }
 
 Everytime one or more cursors changes state a *cursorupdates* event is emitted on the chart container.
 These events are emitted in one of these situations:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ The plugin supports these options:
             lineWidth: number,
             position: {
                 relativeX or x or x2 or x3 ..: number,
-                relativeY or y or y2 or y3 ..: number,
+                relativeY or y or y2 or y3 ..: number
+            },
+            mousePosition: {
+                relativeX: number,
+                relativeY: number
             },
             show: true or false,
             showLabel: true or false,
@@ -112,9 +116,18 @@ The plugin adds some public methods to the plot:
     remove the specified cursor from the plot. cursorToRemove is a cursor
     reference to one of the cursors obtained with getCursors()
 
-* plot.setCursor ( cursor , options)
+* plot.setCursor(cursor , options)
 
     changes one or more cursor properties.
+	
+* plot.getIntersections(cursor)
+
+    returns the intersections of the cursor with plots 	
+	
+* plot.formatCursorPosition(plot, cursor)
+
+    return the formatted text values of the position of cursor as an 
+	object { xTextValue, yTextValue }
 
 Everytime one or more cursors changes state a *cursorupdates* event is emitted on the chart container.
 These events are emitted in one of these situations:

--- a/jquery.flot.cursors.js
+++ b/jquery.flot.cursors.js
@@ -325,7 +325,9 @@ Licensed under the MIT license.
                 cursorLastMouseY = cursor.mouseRelativeY * plot.height(),
                 nearestPoint = plot.findNearbyItem(cursorLastMouseX, cursorLastMouseY, function(seriesIndex) {
                     return seriesIndex === cursor.snapToPlot;
-                }, Number.MAX_VALUE);
+                }, Number.MAX_VALUE, function(x, y) {
+                    return x * x + y * y * 0.025;
+                });
 
             if (nearestPoint) {
                 var dataset = plot.getData(),

--- a/jquery.flot.cursors.js
+++ b/jquery.flot.cursors.js
@@ -113,7 +113,7 @@ Licensed under the MIT license.
             return [];
         };
 
-        plot.computePositionTextValue = computePositionTextValue;
+        plot.formatCursorPosition = formatCursorPosition;
 
         var selectedCursor = function (cursors) {
             var result;
@@ -594,7 +594,7 @@ Licensed under the MIT license.
         return plot.computeValuePrecision(point1, point2, axis.direction, 1);
     }
 
-    function computePositionTextValue(plot, cursor) {
+    function formatCursorPosition(plot, cursor) {
         if (typeof cursor.showValuesRelativeToSeries === 'number') {
             var dataset = plot.getData(),
                 series = dataset[cursor.showValuesRelativeToSeries],
@@ -626,7 +626,7 @@ Licensed under the MIT license.
 
     function drawValues(plot, ctx, cursor) {
         if (typeof cursor.showValuesRelativeToSeries === 'number') {
-            var positionTextValues = computePositionTextValue(plot, cursor),
+            var positionTextValues = formatCursorPosition(plot, cursor),
                 text = positionTextValues.xTextValue + ", " + positionTextValues.yTextValue,
                 position = computeRowPosition(plot, cursor, valuesRowIndex(cursor), rowCount(cursor));
 

--- a/jquery.flot.cursors.js
+++ b/jquery.flot.cursors.js
@@ -321,9 +321,9 @@ Licensed under the MIT license.
                 return intersections;
             }
 
-            var cursorMouseX = cursor.mouseRelativeX * plot.width(),
-                cursorMouseY = cursor.mouseRelativeY * plot.height(),
-                nearestPoint = plot.findNearbyItem(cursorMouseX, cursorMouseY, function(seriesIndex) {
+            var cursorLastMouseX = cursor.mouseRelativeX * plot.width(),
+                cursorLastMouseY = cursor.mouseRelativeY * plot.height(),
+                nearestPoint = plot.findNearbyItem(cursorLastMouseX, cursorLastMouseY, function(seriesIndex) {
                     return seriesIndex === cursor.snapToPlot;
                 }, Number.MAX_VALUE);
 

--- a/jquery.flot.cursors.js
+++ b/jquery.flot.cursors.js
@@ -113,6 +113,8 @@ Licensed under the MIT license.
             return [];
         };
 
+        plot.computePositionTextValue = computePositionTextValue;
+
         var selectedCursor = function (cursors) {
             var result;
 
@@ -592,7 +594,7 @@ Licensed under the MIT license.
         return plot.computeValuePrecision(point1, point2, axis.direction, 1);
     }
 
-    function drawValues(plot, ctx, cursor) {
+    function computePositionTextValue(plot, cursor) {
         if (typeof cursor.showValuesRelativeToSeries === 'number') {
             var dataset = plot.getData(),
                 series = dataset[cursor.showValuesRelativeToSeries],
@@ -615,7 +617,17 @@ Licensed under the MIT license.
                 yFormattedValue = yFormattedValue.slice(0, spaceIndex);
             }
 
-            var text = xFormattedValue + ', ' + yFormattedValue,
+            return {
+                xTextValue: xFormattedValue,
+                yTextValue: yFormattedValue
+            }
+        }
+    }
+
+    function drawValues(plot, ctx, cursor) {
+        if (typeof cursor.showValuesRelativeToSeries === 'number') {
+            var positionTextValues = computePositionTextValue(plot, cursor),
+                text = positionTextValues.xTextValue + ", " + positionTextValues.yTextValue,
                 position = computeRowPosition(plot, cursor, valuesRowIndex(cursor), rowCount(cursor));
 
             ctx.fillStyle = cursor.color;

--- a/jquery.flot.cursors.js
+++ b/jquery.flot.cursors.js
@@ -33,6 +33,10 @@ Licensed under the MIT license.
                     relativeX: 0.5,
                     relativeY: 0.5
                 },
+                mousePosition: {
+                    relativeX: 0.5,
+                    relativeY: 0.5
+                },
                 x: 0,
                 y: 0,
                 show: true,
@@ -52,9 +56,7 @@ Licensed under the MIT license.
                 mouseButton: 'all',
                 dashes: 1,
                 intersectionColor: 'darkgray',
-                intersectionLabelPosition: 'bottom-right',
-                mouseRelativeX: 0.5,
-                mouseRelativeY: 0.5
+                intersectionLabelPosition: 'bottom-right'
             });
         }
 
@@ -70,8 +72,9 @@ Licensed under the MIT license.
 
         plot.addCursor = function addCursor(options) {
             var currentCursor = createCursor(options);
-            currentCursor.mouseRelativeX = currentCursor.position.relativeX || 0.5;
-            currentCursor.mouseRelativeY = currentCursor.position.relativeY || 0.5;
+
+            currentCursor.mousePosition.relativeX = currentCursor.position.relativeX || 0.5;
+            currentCursor.mousePosition.relativeY = currentCursor.position.relativeY || 0.5;
 
             setPosition(plot, currentCursor, options.position);
 
@@ -222,13 +225,13 @@ Licensed under the MIT license.
                 currentlySelectedCursor.selected = false;
                 if (currentlySelectedCursor.dragmode.indexOf('x') !== -1) {
                     currentlySelectedCursor.x = mouseX;
-                    currentlySelectedCursor.mouseRelativeX = mouseX / plot.width();
+                    currentlySelectedCursor.mousePosition.relativeX = mouseX / plot.width();
                     currentlySelectedCursor.position.relativeX = currentlySelectedCursor.x / plot.width();
                 }
 
                 if (currentlySelectedCursor.dragmode.indexOf('y') !== -1) {
                     currentlySelectedCursor.y = mouseY;
-                    currentlySelectedCursor.mouseRelativeY = mouseY / plot.height();
+                    currentlySelectedCursor.mousePosition.relativeY = mouseY / plot.height();
                     currentlySelectedCursor.position.relativeY = currentlySelectedCursor.y / plot.height();
                 }
 
@@ -248,13 +251,13 @@ Licensed under the MIT license.
                 if (currentlySelectedCursor.dragmode.indexOf('x') !== -1) {
                     currentlySelectedCursor.x = mouseX;
                     currentlySelectedCursor.position.relativeX = currentlySelectedCursor.x / plot.width();
-                    currentlySelectedCursor.mouseRelativeX = mouseX / plot.width();
+                    currentlySelectedCursor.mousePosition.relativeX = mouseX / plot.width();
                 }
 
                 if (currentlySelectedCursor.dragmode.indexOf('y') !== -1) {
                     currentlySelectedCursor.y = mouseY;
                     currentlySelectedCursor.position.relativeY = currentlySelectedCursor.y / plot.height();
-                    currentlySelectedCursor.mouseRelativeY = mouseY / plot.height();
+                    currentlySelectedCursor.mousePosition.relativeY = mouseY / plot.height();
                 }
 
                 plot.triggerRedrawOverlay();
@@ -321,8 +324,8 @@ Licensed under the MIT license.
                 return intersections;
             }
 
-            var cursorLastMouseX = cursor.mouseRelativeX * plot.width(),
-                cursorLastMouseY = cursor.mouseRelativeY * plot.height(),
+            var cursorLastMouseX = cursor.mousePosition.relativeX * plot.width(),
+                cursorLastMouseY = cursor.mousePosition.relativeY * plot.height(),
                 nearestPoint = plot.findNearbyItem(cursorLastMouseX, cursorLastMouseY, function(seriesIndex) {
                     return seriesIndex === cursor.snapToPlot;
                 }, Number.MAX_VALUE, function(x, y) {

--- a/spec/cursors_interaction.Test.js
+++ b/spec/cursors_interaction.Test.js
@@ -108,42 +108,6 @@ describe("Cursors interaction", function () {
         expect(cursor.selected).not.toBe(true);
     });
 
-    xit('should treat a mouseout event as a mouseup', function () {
-        plot = $.plot("#placeholder", [sampledata], {
-            cursors: [
-                {
-                    name: 'Blue cursor',
-                    color: 'blue',
-                    position: {
-                        relativeX: 0.5,
-                        relativeY: 0.6
-                    }
-                }
-            ]
-        });
-
-        var cursorX = plot.offset().left + plot.width() * 0.5;
-        var cursorY = plot.offset().top + plot.height() * 0.6;
-
-        jasmine.clock().tick(20);
-
-        var eventHolder = $('#placeholder').find('.flot-overlay');
-        eventHolder.trigger(new $.Event('mousedown', {
-            pageX: cursorX,
-            pageY: cursorY
-        }));
-
-        var cursor = plot.getCursors()[0];
-        expect(cursor.selected).toBe(true);
-
-        eventHolder.trigger(new $.Event('mouseout', {
-            pageX: cursorX,
-            pageY: cursorY
-        }));
-
-        expect(cursor.selected).toBe(false);
-    });
-
     it('should only listen to the relevant mouse buttons', function() {
         plot = $.plot("#placeholder", [sampledata], {
             cursors: [

--- a/spec/cursors_interaction.Test.js
+++ b/spec/cursors_interaction.Test.js
@@ -108,7 +108,7 @@ describe("Cursors interaction", function () {
         expect(cursor.selected).not.toBe(true);
     });
 
-    it('should treat a mouseout event as a mouseup', function () {
+    xit('should treat a mouseout event as a mouseup', function () {
         plot = $.plot("#placeholder", [sampledata], {
             cursors: [
                 {

--- a/spec/cursors_snapping.Test.js
+++ b/spec/cursors_snapping.Test.js
@@ -203,4 +203,37 @@ describe("Cursors snapping", function () {
         expect(cursor.x).toBe(pos.left);
         expect(cursor.y).toBe(pos.top);
     });
+
+    it('should snap on the closest position on mouse up', function() {
+        plot = $.plot("#placeholder", [sampledata], {
+            cursors: [
+                {
+                    name: 'Blue cursor',
+                    color: 'blue',
+                    position: {
+                        relativeX: 0.2,
+                        relativeY: 0.1
+                    }
+                }
+            ]
+        });
+
+        var cursorX = plot.offset().left + plot.width() * 0.5,
+            cursorY = plot.offset().top + plot.height() * 0.6,
+            cursor = plot.getCursors()[0];
+
+        cursor.selected = true;
+        cursor.dragmode = 'xy';
+
+        jasmine.clock().tick(20);
+
+        var eventHolder = $('#placeholder').find('.flot-overlay');
+        eventHolder.trigger(new $.Event('mouseup', {
+            pageX: cursorX,
+            pageY: cursorY
+        }));
+
+        expect(cursor.position.relativeX).toBe(0.5);
+        expect(cursor.position.relativeY).toBe(0.6);
+    })
 });


### PR DESCRIPTION
* Cursor snap to the nearest point relative to last mouse position instead of the nearest point of current cursor's position

*  When mouse leaves the area of the graph, it is not considered anymore a mouse up event, this causing the current selected cursor to remain selected

* Exposed function which computes the cursor text value as a public API to be able to use it for legends too.